### PR TITLE
lisää dao-testejä

### DIFF
--- a/src/main/java/dao/KirjaDAO.java
+++ b/src/main/java/dao/KirjaDAO.java
@@ -43,6 +43,8 @@ public class KirjaDAO {
             }
         } catch (SQLException ex) {
             System.out.println("SQL kysely epäonnistui: " + ex);
+        } catch (NullPointerException ex) {
+            // Tietokanta-luokka tekee virheilmoituksen.
         }
         
         return kirja;

--- a/src/main/java/dao/TagDAO.java
+++ b/src/main/java/dao/TagDAO.java
@@ -23,14 +23,14 @@ public class TagDAO {
             stmt.setString(1, lisattava.getTag());
             stmt.executeUpdate();
             // Hae uusi ID:
-            try (ResultSet rs = stmt.getGeneratedKeys()) {
-                if (rs.next()) {
-                    uusiId = rs.getLong(1);
-                }
-            } catch (Exception e) {};
+            ResultSet rs = stmt.getGeneratedKeys();
+            uusiId = rs.getLong(1);
             
         } catch (SQLException ex) {
             System.out.println("SQL kysely epäonnistui: " + ex);
+            return -1;
+        } catch (NullPointerException ex) {
+            // Tietokanta-luokka tekee virheilmoituksen.
             return -1;
         }
 
@@ -49,6 +49,8 @@ public class TagDAO {
             tag = new Tag(result.getString("tag"));
         } catch (SQLException ex) {
             System.out.println("SQL kysely epäonnistui: " + ex);
+        } catch (NullPointerException ex) {
+            // Tietokanta-luokka tekee virheilmoituksen.
         }
 
         return tag;

--- a/src/main/java/dao/VideoDAO.java
+++ b/src/main/java/dao/VideoDAO.java
@@ -52,6 +52,8 @@ public class VideoDAO {
             }
         } catch (SQLException ex) {
             System.out.println("SQL kysely epäonnistui: " + ex);
+        } catch (NullPointerException ex) {
+            // Tietokanta-luokka tekee virheilmoituksen.
         }
         
         return video;

--- a/src/main/java/dao/VinkkiDAO.java
+++ b/src/main/java/dao/VinkkiDAO.java
@@ -40,16 +40,15 @@ public class VinkkiDAO {
             stmt.executeUpdate();
 
             // Hae uusi ID ja aseta se oliolle:
-            try (ResultSet rs = stmt.getGeneratedKeys()) {
-                if (rs.next()) {
-                    vinkkiId = rs.getLong(1);
-                    lisattava.setId(vinkkiId);
-                }
-            } catch (Exception e) {
-            }
+            ResultSet rs = stmt.getGeneratedKeys();
+            vinkkiId = rs.getLong(1);
+            lisattava.setId(vinkkiId);
 
         } catch (SQLException ex) {
             System.out.println("SQL kysely epäonnistui: " + ex);
+            return -1;
+        } catch (NullPointerException ex) {
+            // Tietokanta-luokka tekee virheilmoituksen.
             return -1;
         }
         
@@ -65,7 +64,7 @@ public class VinkkiDAO {
         for (Tag tag : tagit) {
             // Lisätään tag.
             long tagId = tagDao.lisaaTag(tag);
-
+            
             // Liitetään tag Vinkkiin.
             String vinkkiTagQuery = "INSERT INTO VinkkiTag (vinkki, tag) values (?, ?)";
 
@@ -77,6 +76,9 @@ public class VinkkiDAO {
 
             } catch (SQLException ex) {
                 System.out.println("SQL kysely epäonnistui: " + ex);
+                return false;
+            } catch (NullPointerException ex) {
+                // Tietokanta-luokka tekee virheilmoituksen.
                 return false;
             }
         }
@@ -97,6 +99,8 @@ public class VinkkiDAO {
             }
         } catch (SQLException ex) {
             System.out.println("SQL kysely epäonnistui: " + ex);
+        } catch (NullPointerException ex) {
+            // Tietokanta-luokka tekee virheilmoituksen.
         }
 
         return vinkit;
@@ -154,6 +158,9 @@ public class VinkkiDAO {
             }
         } catch (SQLException e) {
             System.err.println("SQLException: " + e);
+            return null;
+        } catch (NullPointerException ex) {
+            // Tietokanta-luokka tekee virheilmoituksen.
             return null;
         }
         

--- a/src/test/java/dao/KirjaDAOTest.java
+++ b/src/test/java/dao/KirjaDAOTest.java
@@ -72,6 +72,20 @@ public class KirjaDAOTest {
     }
     
     @Test
+    public void huonoTietokantaosoitePalauttaaNeg1Lisatessa() {
+        Tietokanta huonoDB = new Tietokanta("");
+        KirjaDAO huonoDao = new KirjaDAO(huonoDB);
+        assertEquals(-1, huonoDao.lisaaKirja(new Kirja("Ots", "kuv", "isb", "kirj")));
+    }
+    
+    @Test
+    public void huonoTietokantaosoitePalauttaaNullHakiessa() {
+        Tietokanta huonoDB = new Tietokanta("");
+        KirjaDAO huonoDao = new KirjaDAO(huonoDB);
+        assertEquals(null, huonoDao.haeKirja(1));
+    }
+    
+    @Test
     public void olemattomanKirjanHakuPalauttaaNull() {
         assertEquals(null, dao.haeKirja(-1l));
     }

--- a/src/test/java/dao/TagDAOTest.java
+++ b/src/test/java/dao/TagDAOTest.java
@@ -48,4 +48,18 @@ public class TagDAOTest {
         TagDAO huonoDao = new TagDAO(huonoDB);
         assertEquals(null, huonoDao.haeTag(1));
     }
+    
+    @Test
+    public void huonoTietokantaosoitePalauttaaNeg1Lisatessa() {
+        Tietokanta huonoDB = new Tietokanta("");
+        TagDAO huonoDao = new TagDAO(huonoDB);
+        assertEquals(-1, huonoDao.lisaaTag(new Tag("tagii")));
+    }
+    
+    @Test
+    public void huonoTietokantaosoitePalauttaaNullHakiessa() {
+        Tietokanta huonoDB = new Tietokanta("");
+        TagDAO huonoDao = new TagDAO(huonoDB);
+        assertEquals(null, huonoDao.haeTag(1));
+    }
 }

--- a/src/test/java/dao/VideoDAOTest.java
+++ b/src/test/java/dao/VideoDAOTest.java
@@ -94,4 +94,18 @@ public class VideoDAOTest {
     public void olemattomanVideonHakuPalauttaaNull() {
         assertEquals(null, dao.haeVideo(-1l));
     }
+    
+    @Test
+    public void huonoTietokantaosoitePalauttaaNeg1Lisatessa() {
+        Tietokanta huonoDB = new Tietokanta("");
+        VideoDAO huonoDao = new VideoDAO(huonoDB);
+        assertEquals(-1, huonoDao.lisaaVideo(new Video("Ots", "kuv", "tekija", "url", "pvm")));
+    }
+    
+    @Test
+    public void huonoTietokantaosoitePalauttaaNullHakiessa() {
+        Tietokanta huonoDB = new Tietokanta("");
+        VideoDAO huonoDao = new VideoDAO(huonoDB);
+        assertEquals(null, huonoDao.haeVideo(1));
+    }
 }

--- a/src/test/java/dao/VinkkiDAOTest.java
+++ b/src/test/java/dao/VinkkiDAOTest.java
@@ -58,4 +58,27 @@ public class VinkkiDAOTest {
         lisattava.lisaaTag(new Tag(null));
         assertEquals(-1l, dao.lisaaVinkki(lisattava));
     }
+    
+    @Test
+    public void kaikkiVinkitJaTiedotHuonollaTietokantaosoitteellaPalauttaaNull() {
+        Tietokanta huonoDB = new Tietokanta("");
+        VinkkiDAO huonoDao = new VinkkiDAO(huonoDB);
+        assertEquals(null, huonoDao.kaikkiVinkitJaTiedot());
+    }
+    
+    @Test
+    public void lisaaVinkkiTagHuonollaTietokantaosoitteellaPalauttaaFalse() {
+        Tietokanta huonoDB = new Tietokanta("");
+        VinkkiDAO huonoDao = new VinkkiDAO(huonoDB);
+        Vinkki lisattava = new Vinkki("ots", "kuv", "kirja");
+        lisattava.lisaaTag(new Tag("doot"));
+        assertFalse(huonoDao.lisaaVinkkiTag(lisattava.getTagit(), 1l));
+    }
+    
+    @Test
+    public void kaikkiVinkitHuonollaTietokantaosoitteellaPalauttaaTyhjanListan() {
+        Tietokanta huonoDB = new Tietokanta("");
+        VinkkiDAO huonoDao = new VinkkiDAO(huonoDB);
+        assertTrue(huonoDao.kaikkiVinkit().isEmpty());
+    }
 }


### PR DESCRIPTION
Luulin parantavani testikattavuutta testaamalla lisää poikkeustapauksia. Prosenttiosuus pysyy samana, sillä toteutin poikkeuskäsittelyt testattaville poikkeuksille.

Poistin pari mielestäni turhaa try-catch ja if varmistusta. Jos ne oli tärkeitä, kirjoita testi, joka failaa ilman niitä.