### PR TITLE
blogin lisääminen sovelluslogiikkaan ja käyttikseen + testidataa

### DIFF
--- a/Dokumentaatio/tietokanta/insert_lauseet.txt
+++ b/Dokumentaatio/tietokanta/insert_lauseet.txt
@@ -1,0 +1,73 @@
+INSERT INTO Vinkki (otsikko, kuvaus, tyyppi) VALUES ("Introduction to Algorithms","The algorithms are described in English and in a pseudocode designed to be readable by anyone who has done a little programming.", "kirja");
+INSERT INTO Kirja (vinkki, ISBN, kirjailija) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),"9780262033848" ,"James Cormen");
+INSERT INTO Tag (tag) VALUES ("algoritmit");
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag ORDER BY tag_id DESC LIMIT 1));
+INSERT INTO Tag (tag) VALUES ("Tira");
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag ORDER BY tag_id DESC LIMIT 1));
+
+INSERT INTO Vinkki (otsikko, kuvaus, tyyppi) VALUES ("The Art of Agile development","The Art of Agile Development contains practical guidance for anyone considering or applying agile development for building valuable software.", "kirja");
+INSERT INTO Kirja (vinkki, ISBN, kirjailija) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),"9780596527679" ,"James Shore");
+INSERT INTO Tag (tag) VALUES ("ohtu");
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag ORDER BY tag_id DESC LIMIT 1));
+INSERT INTO Tag (tag) VALUES ("agile");
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag ORDER BY tag_id DESC LIMIT 1));
+INSERT INTO Tag (tag) VALUES ("developers");
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag ORDER BY tag_id DESC LIMIT 1));
+
+INSERT INTO Vinkki (otsikko, kuvaus, tyyppi) VALUES ("The Agile Samurai","Combining cutting-edge tools with classic agile practices, The Agile Samurai gives you everything you need to deliver something of value every week and make rolling your software into production a non-event.", "kirja");
+INSERT INTO Kirja (vinkki, ISBN, kirjailija) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),"9781934356586" ,"Jonathan Rasmusson");
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag WHERE tag = "ohtu" LIMIT 1));
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag WHERE tag = "agile" LIMIT 1));
+INSERT INTO Tag (tag) VALUES ("tools");
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag ORDER BY tag_id DESC LIMIT 1));
+
+INSERT INTO Vinkki (otsikko, kuvaus, tyyppi) VALUES ("Agile In Practice: StoryCards/User Stories","This video is part of the Agile Academy's Agile in Practice series to support our Practice Help Sheets on our website at www.agileacademy.com.au. There is more to Agile success than just using practices. However, practices can serve as valuable techniques to assist you in working Agile.", "video");
+INSERT INTO Video (vinkki, tekija, url, pvm) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),"AgileAcademyAus", "https://www.youtube.com/watch?v=LGeDZmrWwsw", "20.3.2011");
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag WHERE tag = "ohtu" LIMIT 1));
+INSERT INTO Tag (tag) VALUES ("user story");
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag ORDER BY tag_id DESC LIMIT 1));
+
+INSERT INTO Vinkki (otsikko, kuvaus, tyyppi) VALUES ("60 Second Scrum Organizing the Product Backlog","Is your Product Backlog growing too large to manage?  Here are some tips to get it under control.", "video");
+INSERT INTO Video (vinkki, tekija, url, pvm) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),"Angela Druckman", "https://www.youtube.com/watch?v=g92anflQgyY", "26.11.2012");
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag WHERE tag = "ohtu" LIMIT 1));
+INSERT INTO Tag (tag) VALUES ("product backlog");
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag ORDER BY tag_id DESC LIMIT 1));
+
+INSERT INTO Vinkki (otsikko, kuvaus, tyyppi) VALUES ("Eric Ries: "The Lean Startup" | Talks at Google","Eric is the author of the popular blog Startup Lessons Learned and the creator of the Lean Startup methodology. He co-founded and served as CTO of IMVU, his third startup, which has today has over 40 million users and 2009 revenue over $22 million.", "video");
+INSERT INTO Video (vinkki, tekija, url, pvm) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),"Talks at Google", "https://www.youtube.com/watch?v=fEvKo90qBns", "7.4.2011");
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag WHERE tag = "ohtu" LIMIT 1));
+INSERT INTO Tag (tag) VALUES ("lean startup");
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag ORDER BY tag_id DESC LIMIT 1));
+
+INSERT INTO Vinkki (otsikko, kuvaus, tyyppi) VALUES ("Add the Right Amount of Detail to User Stories","Talking about the timing and the detail of user stories. Points also to a video advicing what to do right now.", "blogi");
+INSERT INTO Blogi (vinkki, kirjoittaja, url, pvm) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),"Mike Cohn", "https://www.mountaingoatsoftware.com/blog/add-the-right-amount-of-detail-to-user-stories", "3.10.2017");
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag WHERE tag = "ohtu" LIMIT 1));
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag WHERE tag = "user story" LIMIT 1));
+
+INSERT INTO Vinkki (otsikko, kuvaus, tyyppi) VALUES ("How to communicate bad news to your project sponsor","Delivering bad news to your project sponsor is not an easy task that any project manager. You never know what you can expect.", "blogi");
+INSERT INTO Blogi (vinkki, kirjoittaja, url, pvm) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),"Helena Liu", "https://www.ronrosenhead.co.uk/6952/communicate-bad-news-project-sponsor/", "27.9.2017");
+INSERT INTO Tag (tag) VALUES ("projektit");
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag ORDER BY tag_id DESC LIMIT 1));
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag WHERE tag = "ohtu" LIMIT 1));
+
+INSERT INTO Vinkki (otsikko, kuvaus, tyyppi) VALUES ("Remote Agile Teams","Results of a survey about how agile teams work when team members don't work in the same place.", "blogi");
+INSERT INTO Blogi (vinkki, kirjoittaja, url, pvm) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),"Sam Laing", "https://www.growingagile.co.za/2017/07/remote-agile-teams/", "25.7.2017");
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag WHERE tag = "agile" LIMIT 1));
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag WHERE tag = "ohtu" LIMIT 1));
+
+INSERT INTO Vinkki (otsikko, kuvaus, tyyppi) VALUES ("Episode 130: Intelligent Monkeys","Discussion about the value of automation and what is the right amount of automation.", "podcast");
+INSERT INTO Podcast (vinkki, tekija, url, pvm) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),"Amos King, Craig Buchek, John Sextro, Lee McCauley", "http://www.thisagilelife.com/130", "24.9.2017");
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag WHERE tag = "ohtu" LIMIT 1));
+INSERT INTO Tag (tag) VALUES ("automation");
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag ORDER BY tag_id DESC LIMIT 1));
+
+INSERT INTO Vinkki (otsikko, kuvaus, tyyppi) VALUES ("Joe Anderson on using Retrospectives for self-development as well as team development","As Scrum Masters we are intimately familiar with Retrospectives. We plan, organize and facilitate retrospectives for our team members and even larger chunks of the organization. But when was the last time you did your own personal retrospective?", "podcast");
+INSERT INTO Podcast (vinkki, tekija, url, pvm) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),"Joe Anderson", "http://scrum-master-toolbox.org/2017/11/podcast/joe-anderson-on-using-retrospectives-for-self-development-as-well-as-team-development/", "30.11.2017");
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag WHERE tag = "ohtu" LIMIT 1));
+INSERT INTO Tag (tag) VALUES ("scrum");
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag ORDER BY tag_id DESC LIMIT 1));
+
+INSERT INTO Vinkki (otsikko, kuvaus, tyyppi) VALUES ("Donald Ewart the 3 steps to mastery for Scrum teams","Podcast discussed leadership. "Powerful Questions" is recommended as a tool that helps Scrum Masters to initiate right kind of discussions with the team.", "podcast");
+INSERT INTO Podcast (vinkki, tekija, url, pvm) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),"Donald Ewart", "http://scrum-master-toolbox.org/2017/11/podcast/donald-ewart-the-3-steps-to-mastery-for-scrum-teams/", "16.11.2017");
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag WHERE tag = "scrum" LIMIT 1));
+INSERT INTO VinkkiTag (vinkki, tag) VALUES ((SELECT vinkki_id FROM Vinkki ORDER BY vinkki_id DESC LIMIT 1),(SELECT tag_id FROM Tag WHERE tag = "ohtu" LIMIT 1));

--- a/Dokumentaatio/tietokanta/lisattavat_datat.txt
+++ b/Dokumentaatio/tietokanta/lisattavat_datat.txt
@@ -1,0 +1,98 @@
+
+
+Kirjat: 
+
+Introduction to Algorithms
+The algorithms are described in English and in a pseudocode designed to be readable by anyone who has done a little programming. 
+9780262033848
+James Cormen
+algoritmit, Tira
+
+The Art of Agile development
+The Art of Agile Development contains practical guidance for anyone considering or applying agile development for building valuable software. Plenty of books describe what agile development is or why it helps software projects succeed, but very few combine information for developers, managers, testers, and customers into a single package that they can apply directly.
+9780596527679
+James Shore
+ohtu, agile, developers
+
+The Agile Samurai
+Combining cutting-edge tools with classic agile practices, The Agile Samurai gives you everything you need to deliver something of value every week and make rolling your software into production a non-event.
+9781934356586
+Jonathan Rasmusson
+ohtu, agile, tools
+
+Videot:
+
+Agile In Practice: StoryCards/User Stories
+This video is part of the Agile Academy's Agile in Practice series to support our Practice Help Sheets on our website at www.agileacademy.com.au. There is more to Agile success than just using practices. However, practices can serve as valuable techniques to assist you in working Agile.
+AgileAcademyAus
+https://www.youtube.com/watch?v=LGeDZmrWwsw
+20.3.2011
+ohtu, user story
+
+60 Second Scrum Organizing the Product Backlog
+Is your Product Backlog growing too large to manage?  Here are some tips to get it under control.
+Angela Druckman
+https://www.youtube.com/watch?v=g92anflQgyY
+
+
+26.11.2012
+ohtu, product backlog
+
+Eric Ries: "The Lean Startup" | Talks at Google
+https://www.youtube.com/watch?v=fEvKo90qBns
+Talks at Google
+Eric is the author of the popular blog Startup Lessons Learned and the creator of the Lean Startup methodology. He co-founded and served as CTO of IMVU, his third startup, which has today has over 40 million users and 2009 revenue over $22 million.
+7.4.2011
+ohtu, lean startup
+
+Blogit:
+
+Add the Right Amount of Detail to User Stories
+Talking about the timing and the detail of user stories. Points also to a video advicing what to do right now.
+Mike Cohn
+https://www.mountaingoatsoftware.com/blog/add-the-right-amount-of-detail-to-user-stories
+3.10.2017
+ohtu, user story
+Blogin nimi: Mountain Goat Software Blog
+
+How to communicate bad news to your project sponsor
+Delivering bad news to your project sponsor is not an easy task that any project manager. You never know what you can expect. 
+Helena Liu
+https://www.ronrosenhead.co.uk/6952/communicate-bad-news-project-sponsor/
+27.9.2017
+projektit, ohtu
+Blogin nimi: Ron Rosenhead's blog
+
+Remote Agile Teams
+Results of a survey about how agile teams work when team members don't work in the same place.
+Sam Laing
+https://www.growingagile.co.za/2017/07/remote-agile-teams/
+25.7.2017
+agile, ohtu
+Blogin nimi: Growing Agile Blog
+
+Podcastit:
+
+Episode 130: Intelligent Monkeys
+Discussion about the value of automation and what is the right amount of automation.
+Amos King, Craig Buchek, John Sextro, Lee McCauley
+http://www.thisagilelife.com/130
+24.9.2017
+automation, ohtu
+Podcastin nimi: This Agile Life
+
+Joe Anderson on using Retrospectives for self-development as well as team development
+As Scrum Masters we are intimately familiar with Retrospectives. We plan, organize and facilitate retrospectives for our team members and even larger chunks of the organization. But when was the last time you did your own personal retrospective?
+Joe Anderson
+http://scrum-master-toolbox.org/2017/11/podcast/joe-anderson-on-using-retrospectives-for-self-development-as-well-as-team-development/
+30.11.2017
+ohtu, scrum
+Podcastin nimi: Scrum Master Toolbox Podcast
+
+Donald Ewart the 3 steps to mastery for Scrum teams
+Podcast discussed leadership. "Powerful Questions" is recommended as a tool that helps Scrum Masters to initiate right kind of discussions with the team.
+Donald Ewart
+http://scrum-master-toolbox.org/2017/11/podcast/donald-ewart-the-3-steps-to-mastery-for-scrum-teams/
+16.11.2017
+scrum, ohtu
+Podcastin nimi: Scrum Master Toolbox Podcast

--- a/src/main/java/dao/VinkkiDAO.java
+++ b/src/main/java/dao/VinkkiDAO.java
@@ -144,6 +144,14 @@ public class VinkkiDAO {
                             result.getString("url"),
                             result.getString("pvm")
                     );
+                } else if(tyyppi.equals("blogi")) {
+                    vinkki = new Blogi(
+                            result.getString("otsikko"),
+                            result.getString("kuvaus"),
+                            result.getString("kirjoittaja"),
+                            result.getString("url"),
+                            result.getString("pvm")
+                    );
                 } else {
                     System.err.println("Tunnistamaton vinkin tyyppi: " + tyyppi);
                     continue;

--- a/src/main/java/dao/VinkkiDAO.java
+++ b/src/main/java/dao/VinkkiDAO.java
@@ -112,7 +112,11 @@ public class VinkkiDAO {
         List<Vinkki> vinkit = new ArrayList<>();
         
         // Tähän lauseeseen ei toivottavasti tarvitse enää koskea ikinä.
-        String query = "SELECT * FROM Vinkki "
+        String query = "SELECT vinkki.otsikko, vinkki.kuvaus, vinkki.tyyppi, kirja.isbn, kirja.kirjailija, video.tekija, "
+                + "video.url AS video_url, video.pvm AS video_pvm, blogi.kirjoittaja, blogi.url AS blogi_url, "
+                + "blogi.pvm AS blogi_pvm, podcast.tekija AS podcast_tekija, podcast.url AS podcast_url,"
+                + "podcast.pvm AS podcast_pvm, R.tagit "
+                + "FROM Vinkki "
                 + "LEFT OUTER JOIN Kirja ON Vinkki.vinkki_id = Kirja.vinkki "
                 + "LEFT OUTER JOIN Video ON Vinkki.vinkki_id = Video.vinkki "
                 + "LEFT OUTER JOIN Blogi ON Vinkki.vinkki_id = Blogi.vinkki "
@@ -141,16 +145,16 @@ public class VinkkiDAO {
                             result.getString("otsikko"),
                             result.getString("kuvaus"),
                             result.getString("tekija"),
-                            result.getString("url"),
-                            result.getString("pvm")
+                            result.getString("video_url"),
+                            result.getString("video_pvm")
                     );
                 } else if(tyyppi.equals("blogi")) {
                     vinkki = new Blogi(
                             result.getString("otsikko"),
                             result.getString("kuvaus"),
                             result.getString("kirjoittaja"),
-                            result.getString("url"),
-                            result.getString("pvm")
+                            result.getString("blogi_url"),
+                            result.getString("blogi_pvm")
                     );
                 } else {
                     System.err.println("Tunnistamaton vinkin tyyppi: " + tyyppi);

--- a/src/main/java/logiikka/Logiikka.java
+++ b/src/main/java/logiikka/Logiikka.java
@@ -11,12 +11,14 @@ public class Logiikka {
     private VinkkiDAO vinkkiDao;
     private KirjaDAO kirjaDao;
     private VideoDAO videoDao;
+    private BlogiDAO blogiDao;
 
     public Logiikka(Tietokanta db) {
         this.db = db;
         this.vinkkiDao = new VinkkiDAO(db);
         this.kirjaDao = new KirjaDAO(db);
         this.videoDao = new VideoDAO(db);
+        this.blogiDao = new BlogiDAO(db);
     }
 
     public List<Vinkki> kaikkiVinkit() {
@@ -31,6 +33,9 @@ public class Logiikka {
         if (vinkki.getTyyppi().equals("video")) {
             return lisaaVideo((Video) vinkki);
         }
+        if (vinkki.getTyyppi().equals("blogi")) {
+            return lisaaBlogi((Blogi) vinkki);
+        }
         return null;
     }
 
@@ -44,6 +49,12 @@ public class Logiikka {
         long id = videoDao.lisaaVideo(video);
         Video uusiVideo = videoDao.haeVideo(id);
         return uusiVideo;
+    }
+    
+    private Blogi lisaaBlogi(Blogi blogi) {
+        long id = blogiDao.lisaaBlogi(blogi);
+        Blogi uusiBlogi = blogiDao.haeBlogi(id);
+        return uusiBlogi;
     }
 
     public List<Vinkki> haeKaikkiVinkit() {

--- a/src/main/java/tekstikayttis/Tekstikayttis.java
+++ b/src/main/java/tekstikayttis/Tekstikayttis.java
@@ -8,6 +8,7 @@ import logiikka.Logiikka;
 import tietokantaobjektit.Kirja;
 import tietokantaobjektit.Tag;
 import tietokantaobjektit.Video;
+import tietokantaobjektit.Blogi;
 
 /**
  * Created by hanna-leena on 17/11/17.
@@ -51,8 +52,9 @@ public class Tekstikayttis {
         //ja sen mukaan kysytään lisätietoja
         this.io.print("");
         this.io.print("Minkätyyppisen vinkin haluat lisätä? Valitse alta:");
-        this.io.print("2: Video");
         this.io.print("1: Kirja");
+        this.io.print("2: Video");
+        this.io.print("3: Blogi");
         this.io.print("0: Peruuta");
         String komento = this.io.nextLine();
 
@@ -60,12 +62,30 @@ public class Tekstikayttis {
             this.kirjanLisays();
         } else if (komento.equals("2")) {
             this.videonLisays();
+        } else if(komento.equals("3")){
+            this.bloginLisays();
         } else if (komento.equals("0")) {
             return;
         } else {
             this.io.print("Valitse toiminto listasta!");
             this.vinkinLisays();
         }
+    }
+    
+    public void bloginLisays(){
+        this.io.print("");
+        String otsikko = kysyKentta("otsikko");
+        String kuvaus = kysyKentta("kuvaus");
+        String tekija = kysyKentta("tekijä");
+        String url = kysyKentta("url");
+        String pvm = kysyKentta("pvm");
+        
+        Blogi lisattava = new Blogi(otsikko, kuvaus, tekija, url, pvm);
+        kysyTagit(lisattava);
+
+        this.io.print("");
+        
+        lisaaVinkkiJaTulostaTiedot(lisattava);
     }
 
     public void videonLisays() {


### PR DESCRIPTION
Lisäsin sovelluslogiikkaan ja käyttikseen blogin lisäämisen ja yritin saada myös tiedot tulostumaan.
HUOM: Blogin url ja pvm tulostuvat nyt null:eina, vaikka tietokannassa tietoja olisi, jotain vikaa siis tietokantahaussa. En myöskään ehtinyt tehdä testejä blogille.

Lisäsin Dokumentaatio-kansioon Jemin ansiokkaan oppaan mukan tehtyjä insert-lauseita testidatalle (file insert_lauseet.txt). Sieltä löytyy kolme esimerkkiä kirjalle, videolle, blogille ja podcastille. Selkokieliset kirjoitukset löytyy fileestä lisattavat_datat.txt.Siellä on myös blogipostaukselle ja podcast-jaksolle tieto blogista / podcastista, jos sellainen vielä lisätään.